### PR TITLE
feat: add nix flake for declarative installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,40 @@ sudo zypper install --allow-unsigned-rpm updo_VERSION_linux_amd64.rpm
 </details>
 
 <details>
+<summary>Nix/NixOS</summary>
+
+**Run directly:**
+
+```bash
+nix run github:Owloops/updo -- monitor https://example.com
+```
+
+**Temporary shell:**
+
+```bash
+nix shell github:Owloops/updo
+updo --version
+```
+
+**System flake integration:**
+
+```nix
+{
+  inputs.updo.url = "github:Owloops/updo";
+
+  outputs = { self, nixpkgs, updo }: {
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      modules = [{
+        environment.systemPackages = [ updo.packages.x86_64-linux.default ];
+      }];
+    };
+  };
+}
+```
+
+</details>
+
+<details>
 <summary>Windows - Direct Download</summary>
 
 **PowerShell:**

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -74,6 +74,48 @@ git commit -m "feat: update lambda functionality"
 
 This ensures `go install github.com/Owloops/updo@latest` continues to work for users.
 
+## Updating the Nix Flake
+
+After creating a release, update the Nix flake to make the new version available to Nix users:
+
+1. **Update the version in flake.nix**
+
+   ```bash
+   # Edit flake.nix and update the version field
+   # Change: version = "0.4.5";
+   # To:     version = "0.4.6";  (or your new version)
+   ```
+
+2. **Update vendorHash if dependencies changed**
+
+   If `go.mod` or `go.sum` changed in this release:
+
+   ```bash
+   # Build will fail and show the correct hash
+   nix build --no-link
+
+   # Copy the correct hash from the error message:
+   # "got: sha256-XXXXX..."
+   # Update vendorHash in flake.nix with this value
+   ```
+
+3. **Test the flake**
+
+   ```bash
+   # Update flake.lock
+   nix flake update
+
+   # Test the version is correct
+   nix run . -- --version
+   ```
+
+4. **Commit and push the changes**
+
+   ```bash
+   git add flake.nix flake.lock
+   git commit -m "chore: update nix flake to v0.4.6"
+   ```
+
 ## Pre-release Checklist
 
 - [ ] All tests pass

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,81 @@
+{
+  description = "Updo - Website monitoring tool for tracking uptime and performance";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.buildGoModule rec {
+            pname = "updo";
+            version = "0.4.5";
+
+            src = ./.;
+
+            vendorHash = "sha256-ExV9wRFd1Gsv74cU2brhnvHOAkOs9k1A0h6hsqisY1s=";
+
+            # Exclude the lambda directory as it's a separate module
+            excludedPackages = [ "./lambda" ];
+
+            ldflags = [
+              "-s"
+              "-w"
+              "-X main.version=${version}"
+              "-X main.commit=${src.rev or "unknown"}"
+              "-X main.date=1970-01-01T00:00:00Z"
+            ];
+
+            meta = with pkgs.lib; {
+              description = "Command-line tool for monitoring website uptime and performance";
+              homepage = "https://github.com/Owloops/updo";
+              license = licenses.mit;
+              maintainers = [ ];
+              mainProgram = "updo";
+            };
+          };
+
+          updo = self.packages.${system}.default;
+        }
+      );
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/updo";
+        };
+
+        updo = self.apps.${system}.default;
+      });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              go
+              gopls
+              gotools
+              go-tools
+            ];
+
+            shellHook = ''
+              echo "Updo development environment"
+              echo "Go version: $(go version)"
+            '';
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
Add flake.nix to enable Nix users to install and run updo
  through the Nix package manager. The flake provides:

  - buildGoModule derivation with proper Go dependencies (v0.4.5)
  - Default package and app outputs for easy installation
  - Development shell with Go tooling (go, gopls, gotools)
  - Support for all Nix-supported systems (x86_64/aarch64 linux/darwin)
  - Version injection via ldflags matching goreleaser behavior

  Documentation updates:
  - Added Nix/NixOS installation section to README with usage examples
  - Added flake maintenance instructions to docs/RELEASE.md