### PR TITLE
fix(cmd): remove dead logEnabled variable

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -92,8 +92,7 @@ func init() {
 	RootCmd.PersistentFlags().StringArrayVar(&AppConfig.WebhookHeaders, "webhook-header", nil, "Webhook headers (can be used multiple times, format: 'Header-Name: value')")
 	RootCmd.PersistentFlags().StringVar(&AppConfig.PrometheusURL, "prometheus-url", "", "Prometheus remote write endpoint URL (e.g., http://localhost:9090/api/v1/write)")
 
-	var logEnabled bool
-	RootCmd.PersistentFlags().BoolVar(&logEnabled, "log", false, "Output structured logs in JSON format (includes requests, responses, and metrics)")
+	RootCmd.PersistentFlags().Bool("log", false, "Output structured logs in JSON format (includes requests, responses, and metrics)")
 
 	RootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		refresh, _ := cmd.Flags().GetInt("refresh")


### PR DESCRIPTION
## Problem
`logEnabled` was bound via `BoolVar` but never read. The `PersistentPreRun` 
closure uses `:=` which creates a new local variable, shadowing the bound one.

## Fix
Replace `BoolVar` with a simple `Bool` flag registration. No behaviour change