### PR TITLE
fix(net): limit response body reads with io.LimitReader to 1 MiB

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -344,7 +344,8 @@ func makeHTTPRequest(urlStr string, options HTTPRequestOptions, config NetworkCo
 		}
 	}()
 
-	bodyBytes, err := io.ReadAll(resp.Body)
+	// Limit body reads to 1 MiB to prevent memory exhaustion
+	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		result.Error = err
 		return result


### PR DESCRIPTION
## Problem
`io.ReadAll` reads the entire response body with no size limit. A target 
returning a large response (e.g. a file download endpoint) would exhaust RAM.

## Fix
Wrap `resp.Body` with `io.LimitReader` capped at 1 MiB. Sufficient for 
assertion checks while bounding memory usage.