### PR TITLE
refactor(httputil): extract duplicate parseHeaders into shared package

### DIFF
--- a/httputil/headers.go
+++ b/httputil/headers.go
@@ -1,0 +1,17 @@
+package httputil
+
+import "strings"
+
+// ParseHeaders converts a slice of "Key: Value" headers into a map.
+func ParseHeaders(headers []string) map[string]string {
+	headerMap := make(map[string]string, len(headers))
+	for _, header := range headers {
+		parts := strings.SplitN(header, ":", 2)
+		if len(parts) == 2 {
+			key := strings.TrimSpace(parts[0])
+			value := strings.TrimSpace(parts[1])
+			headerMap[key] = value
+		}
+	}
+	return headerMap
+}

--- a/httputil/headers_test.go
+++ b/httputil/headers_test.go
@@ -1,0 +1,48 @@
+package httputil
+
+import "testing"
+
+func TestParseHeaders(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  []string
+		expected map[string]string
+	}{
+		{
+			name:     "valid headers",
+			headers:  []string{"Content-Type: application/json", "Authorization: Bearer token"},
+			expected: map[string]string{"Content-Type": "application/json", "Authorization": "Bearer token"},
+		},
+		{
+			name:     "headers with spaces",
+			headers:  []string{" Content-Type : application/json "},
+			expected: map[string]string{"Content-Type": "application/json"},
+		},
+		{
+			name:     "malformed header skipped",
+			headers:  []string{"valid: header", "invalid-header", "another: valid"},
+			expected: map[string]string{"valid": "header", "another": "valid"},
+		},
+		{
+			name:     "empty headers",
+			headers:  []string{},
+			expected: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseHeaders(tt.headers)
+			if len(got) != len(tt.expected) {
+				t.Errorf("ParseHeaders() returned %d headers, want %d", len(got), len(tt.expected))
+			}
+			for key, expectedValue := range tt.expected {
+				if gotValue, exists := got[key]; !exists {
+					t.Errorf("ParseHeaders() missing key %q", key)
+				} else if gotValue != expectedValue {
+					t.Errorf("ParseHeaders() key %q = %q, want %q", key, gotValue, expectedValue)
+				}
+			}
+		})
+	}
+}

--- a/net/net.go
+++ b/net/net.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/Owloops/updo/httputil"
 )
 
 const (
@@ -22,19 +24,6 @@ const (
 	_userAgent      = "updo/1.0"
 	_httpsPort      = ":443"
 )
-
-func parseHeaders(headers []string) map[string]string {
-	headerMap := make(map[string]string, len(headers))
-	for _, header := range headers {
-		parts := strings.SplitN(header, ":", 2)
-		if len(parts) == 2 {
-			key := strings.TrimSpace(parts[0])
-			value := strings.TrimSpace(parts[1])
-			headerMap[key] = value
-		}
-	}
-	return headerMap
-}
 
 type WebsiteCheckResult struct {
 	URL             string
@@ -108,7 +97,7 @@ func CheckWebsite(urlStr string, config NetworkConfig) WebsiteCheckResult {
 	}
 
 	if len(config.Headers) > 0 {
-		for key, value := range parseHeaders(config.Headers) {
+		for key, value := range httputil.ParseHeaders(config.Headers) {
 			options.Headers[key] = value
 		}
 	}

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -156,51 +156,6 @@ func TestAutoDetectProtocol(t *testing.T) {
 	}
 }
 
-func TestParseHeaders(t *testing.T) {
-	tests := []struct {
-		name     string
-		headers  []string
-		expected map[string]string
-	}{
-		{
-			name:     "valid headers",
-			headers:  []string{"Content-Type: application/json", "Authorization: Bearer token"},
-			expected: map[string]string{"Content-Type": "application/json", "Authorization": "Bearer token"},
-		},
-		{
-			name:     "headers with spaces",
-			headers:  []string{" Content-Type : application/json "},
-			expected: map[string]string{"Content-Type": "application/json"},
-		},
-		{
-			name:     "malformed header skipped",
-			headers:  []string{"valid: header", "invalid-header", "another: valid"},
-			expected: map[string]string{"valid": "header", "another": "valid"},
-		},
-		{
-			name:     "empty headers",
-			headers:  []string{},
-			expected: map[string]string{},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := parseHeaders(tt.headers)
-			if len(got) != len(tt.expected) {
-				t.Errorf("parseHeaders() returned %d headers, want %d", len(got), len(tt.expected))
-			}
-			for key, expectedValue := range tt.expected {
-				if gotValue, exists := got[key]; !exists {
-					t.Errorf("parseHeaders() missing key %q", key)
-				} else if gotValue != expectedValue {
-					t.Errorf("parseHeaders() key %q = %q, want %q", key, gotValue, expectedValue)
-				}
-			}
-		})
-	}
-}
-
 func TestFormatURL(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/notifications/webhook.go
+++ b/notifications/webhook.go
@@ -5,26 +5,14 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"strings"
 	"time"
+
+	"github.com/Owloops/updo/httputil"
 )
 
 const (
 	_webhookTimeout = 10 * time.Second
 )
-
-func parseHeaders(headers []string) map[string]string {
-	headerMap := make(map[string]string, len(headers))
-	for _, header := range headers {
-		parts := strings.SplitN(header, ":", 2)
-		if len(parts) == 2 {
-			key := strings.TrimSpace(parts[0])
-			value := strings.TrimSpace(parts[1])
-			headerMap[key] = value
-		}
-	}
-	return headerMap
-}
 
 type WebhookPayload struct {
 	Event          string    `json:"event"`
@@ -107,7 +95,7 @@ func HandleWebhookAlert(webhookURL string, headers []string, isUp bool, alertSen
 		Error:          errorMsg,
 	}
 
-	headerMap := parseHeaders(headers)
+	headerMap := httputil.ParseHeaders(headers)
 
 	if err := SendWebhook(webhookURL, headerMap, payload); err != nil {
 		return fmt.Errorf("failed to send webhook for %s: %w", displayName, err)

--- a/notifications/webhook_test.go
+++ b/notifications/webhook_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/Owloops/updo/httputil"
 )
 
 func TestSendWebhook(t *testing.T) {
@@ -71,7 +73,7 @@ func TestSendWebhook(t *testing.T) {
 			}))
 			defer server.Close()
 
-			headerMap := parseHeaders(tc.headers)
+			headerMap := httputil.ParseHeaders(tc.headers)
 
 			err := SendWebhook(server.URL, headerMap, tc.payload)
 
@@ -90,7 +92,7 @@ func TestSendWebhook(t *testing.T) {
 					t.Errorf("Target mismatch: expected %s, got %s", tc.payload.Target, receivedPayload.Target)
 				}
 
-				expectedHeaders := parseHeaders(tc.headers)
+				expectedHeaders := httputil.ParseHeaders(tc.headers)
 
 				for key, value := range expectedHeaders {
 					if receivedHeaders.Get(key) != value {


### PR DESCRIPTION
## Problem
`parseHeaders` was duplicated identically in `net/net.go` and 
`notifications/webhook.go`.

## Fix
Extracted into a new `httputil` package as `ParseHeaders`. A new package was 
necessary to avoid an import cycle (`utils` → `net` → `utils`).