### PR TITLE
fix(net): honor Host header override by setting req.Host

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -320,7 +320,11 @@ func makeHTTPRequest(urlStr string, options HTTPRequestOptions, config NetworkCo
 	}
 
 	for name, value := range options.Headers {
-		req.Header.Set(name, value)
+		if strings.EqualFold(name, "Host") {
+			req.Host = value
+		} else {
+			req.Header.Set(name, value)
+		}
 		result.RequestHeaders.Set(name, value)
 	}
 

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -386,7 +386,6 @@ func TestCheckWebsiteWithHostHeader(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Host != wantHost {
 			w.WriteHeader(400)
-			_, _ = w.Write([]byte(r.Host))
 			return
 		}
 		w.WriteHeader(200)
@@ -402,7 +401,7 @@ func TestCheckWebsiteWithHostHeader(t *testing.T) {
 	result := CheckWebsite(server.URL, config)
 
 	if !result.IsUp {
-		t.Errorf("CheckWebsite() with Host header should succeed, got status %d body %q", result.StatusCode, result.ResponseBody)
+		t.Errorf("CheckWebsite() with Host header should succeed, got status %d", result.StatusCode)
 	}
 	if result.StatusCode != 200 {
 		t.Errorf("CheckWebsite() StatusCode = %d, want 200", result.StatusCode)

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -380,6 +380,38 @@ func TestCheckWebsiteWithHeaders(t *testing.T) {
 	}
 }
 
+func TestCheckWebsiteWithHostHeader(t *testing.T) {
+	const wantHost = "virtual.example.com"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Host != wantHost {
+			w.WriteHeader(400)
+			_, _ = w.Write([]byte(r.Host))
+			return
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("OK"))
+	}))
+	defer server.Close()
+
+	config := NetworkConfig{
+		Timeout: 5 * time.Second,
+		Headers: []string{"Host: " + wantHost},
+	}
+
+	result := CheckWebsite(server.URL, config)
+
+	if !result.IsUp {
+		t.Errorf("CheckWebsite() with Host header should succeed, got status %d body %q", result.StatusCode, result.ResponseBody)
+	}
+	if result.StatusCode != 200 {
+		t.Errorf("CheckWebsite() StatusCode = %d, want 200", result.StatusCode)
+	}
+	if got := result.RequestHeaders.Get("Host"); got != wantHost {
+		t.Errorf("RequestHeaders Host = %q, want %q", got, wantHost)
+	}
+}
+
 func TestCheckWebsiteBodyLimit(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
## Problem

Putting `Host` in a target's `headers` array has no effect on the wire. Go's `net/http` ignores `req.Header.Set("Host", ...)` — the value must be assigned to `req.Host`. The server sees the URL's hostname instead of the override.

This breaks a common probe pattern: hitting a load balancer directly (by ELB DNS or IP) while overriding `Host` for virtual-host routing on the backend (ingress controllers, ALB listener rules, nginx vhosts). `curl --header 'Host: ...'` supports it; updo did not match.

### Repro

```toml
[[targets]]
name = "lb-direct"
url = "https://<elb-dns>/.well-known/openid-configuration"
headers = ["Host: service.example.com"]
skip_ssl = true
```

Before fix: backend returns 404 (routed by ELB hostname).
After fix: backend routes by overridden Host, returns 200.

## Fix

In `net/net.go` `makeHTTPRequest`, detect `Host` case-insensitively in the headers loop and assign `req.Host` instead of `req.Header.Set`. Other headers unchanged. `RequestHeaders` still records the override so structured logs show what was sent.

```go
for name, value := range options.Headers {
    if strings.EqualFold(name, "Host") {
        req.Host = value
    } else {
        req.Header.Set(name, value)
    }
    result.RequestHeaders.Set(name, value)
}
```

## Test

New `TestCheckWebsiteWithHostHeader` in `net/net_test.go` — httptest server asserts `r.Host` matches the override and the result records it in `RequestHeaders`. Fails on current main, passes with patch.

## Notes

- TLS SNI still derives from the URL hostname (Go stdlib behavior). Matches `curl --insecure --header 'Host: ...'`. Users hitting an LB by IP or mismatched DNS already need `skip_ssl = true`, same as with curl.
- No config schema change; existing `headers` array keeps working.